### PR TITLE
Add 921600 baudrate option.

### DIFF
--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -30,7 +30,7 @@ export const ADAPTER_MODELS: ReadonlyArray<AdapterModel> = [
     'ROUTER - TubeZB MGM24PB',
 ]
 export const TCP_REGEX = /^tcp:\/\/[\w.-]+:\d+$/
-export const BAUDRATES = [115200, 230400, 460800]
+export const BAUDRATES = [115200, 230400, 460800, 921600]
 /** Read/write max bytes count at stream level */
 export const CONFIG_HIGHWATER_MARK = 256
 


### PR DESCRIPTION
I flashed the firmware [here](https://github.com/Koenkk/zigbee2mqtt/issues/23861#issuecomment-2576257751) and was unable to use ember-zli until I added a 921600 baudrate option. Then restoring tokens seemed to work fine.

Related note: it seems like I'm unable to use any online updaters once flashing the 921600 firmware; do you have any suggestions on how I can now flash firmware to this device?