### PR TITLE
feat: v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g ember-zli
 $ ember-zli COMMAND
 running command...
 $ ember-zli (--version)
-ember-zli/3.3.2 linux-x64 node-v24.9.0
+ember-zli/4.0.0 linux-x64 node-v24.9.0
 $ ember-zli --help [COMMAND]
 USAGE
   $ ember-zli COMMAND
@@ -62,7 +62,7 @@ EXAMPLES
   $ ember-zli bootloader
 ```
 
-_See code: [src/commands/bootloader/index.ts](https://github.com/Nerivec/ember-zli/blob/v3.3.2/src/commands/bootloader/index.ts)_
+_See code: [src/commands/bootloader/index.ts](https://github.com/Nerivec/ember-zli/blob/v4.0.0/src/commands/bootloader/index.ts)_
 
 ## `ember-zli help [COMMAND]`
 
@@ -99,7 +99,7 @@ EXAMPLES
   $ ember-zli monitor
 ```
 
-_See code: [src/commands/monitor/index.ts](https://github.com/Nerivec/ember-zli/blob/v3.3.2/src/commands/monitor/index.ts)_
+_See code: [src/commands/monitor/index.ts](https://github.com/Nerivec/ember-zli/blob/v4.0.0/src/commands/monitor/index.ts)_
 
 ## `ember-zli router`
 
@@ -116,7 +116,7 @@ EXAMPLES
   $ ember-zli router
 ```
 
-_See code: [src/commands/router/index.ts](https://github.com/Nerivec/ember-zli/blob/v3.3.2/src/commands/router/index.ts)_
+_See code: [src/commands/router/index.ts](https://github.com/Nerivec/ember-zli/blob/v4.0.0/src/commands/router/index.ts)_
 
 ## `ember-zli sniff`
 
@@ -133,7 +133,7 @@ EXAMPLES
   $ ember-zli sniff
 ```
 
-_See code: [src/commands/sniff/index.ts](https://github.com/Nerivec/ember-zli/blob/v3.3.2/src/commands/sniff/index.ts)_
+_See code: [src/commands/sniff/index.ts](https://github.com/Nerivec/ember-zli/blob/v4.0.0/src/commands/sniff/index.ts)_
 
 ## `ember-zli stack`
 
@@ -150,7 +150,7 @@ EXAMPLES
   $ ember-zli stack
 ```
 
-_See code: [src/commands/stack/index.ts](https://github.com/Nerivec/ember-zli/blob/v3.3.2/src/commands/stack/index.ts)_
+_See code: [src/commands/stack/index.ts](https://github.com/Nerivec/ember-zli/blob/v4.0.0/src/commands/stack/index.ts)_
 
 ## `ember-zli utils`
 
@@ -167,7 +167,7 @@ EXAMPLES
   $ ember-zli utils
 ```
 
-_See code: [src/commands/utils/index.ts](https://github.com/Nerivec/ember-zli/blob/v3.3.2/src/commands/utils/index.ts)_
+_See code: [src/commands/utils/index.ts](https://github.com/Nerivec/ember-zli/blob/v4.0.0/src/commands/utils/index.ts)_
 
 ## `ember-zli version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ember-zli",
-    "version": "3.3.2",
+    "version": "4.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ember-zli",
-            "version": "3.3.2",
+            "version": "4.0.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@inquirer/prompts": "^8.0.1",
@@ -3143,6 +3143,7 @@
             "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -5042,6 +5043,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5153,6 +5155,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ember-zli",
     "description": "Interact with EmberZNet-based adapters using zigbee-herdsman 'ember' driver",
-    "version": "3.3.2",
+    "version": "4.0.0",
     "author": "Nerivec",
     "bin": {
         "ember-zli": "bin/run.js"

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -86,7 +86,7 @@ export class Transport extends EventEmitter<SerialEventMap> {
         }
     }
 
-    public async initPort(customPortWriter?: TransportWriter): Promise<void> {
+    public async initPort(customPortWriter?: TransportWriter, baudRate = this.portConf.baudRate): Promise<void> {
         // will do nothing if nothing's open
         await this.close(false);
 
@@ -134,7 +134,7 @@ export class Transport extends EventEmitter<SerialEventMap> {
 
         const serialOpts = {
             autoOpen: false,
-            baudRate: this.portConf.baudRate,
+            baudRate,
             dataBits: 8 as const,
             parity: "none" as const,
             path: this.portConf.path,
@@ -162,19 +162,15 @@ export class Transport extends EventEmitter<SerialEventMap> {
     }
 
     public async serialSet(options: SetOptions, afterDelayMS?: number): Promise<void> {
-        try {
-            await new Promise<void>((resolve, reject) => {
-                const fn = (): void => this.#portSerial?.set(options, (error) => (error ? reject(error) : resolve()));
+        await new Promise<void>((resolve, reject) => {
+            const fn = (): void => this.#portSerial?.set(options, (error) => (error ? reject(error) : resolve()));
 
-                if (afterDelayMS) {
-                    setTimeout(fn, afterDelayMS);
-                } else {
-                    fn();
-                }
-            });
-        } catch (error) {
-            logger.warning(`Failed to set serial: ${error}.`, NS);
-        }
+            if (afterDelayMS) {
+                setTimeout(fn, afterDelayMS);
+            } else {
+                fn();
+            }
+        });
     }
 
     public write(buffer: Buffer): void {


### PR DESCRIPTION
- Change `bootloader` prompts to allow more & better behaviors.
- Add generic support for DTR/RTS flipping as method to enter bootloader. (e.g Sonoff Dongle-E)
- Add support for baudrate flipping as method to enter bootloader. (e.g. NabuCasa ZBT-2)
- Fix a few bailout scenario that weren't explicitly closing port.