### PR TITLE
feat: unattended mode for the bootloader command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,66 @@ Interact with the Gecko bootloader in the adapter.
 
 ```
 USAGE
-  $ ember-zli bootloader
+  $ ember-zli bootloader [--port <value>] [--baudrate <value>] [--flow hardware|software] [--adapter Aeotec
+    Zi-Stick (ZGA008)|EasyIOT ZB-GW04 v1.1|EasyIOT ZB-GW04 v1.2|Inswift ZBM-MG24|Nabu Casa SkyConnect|Nabu Casa
+    Yellow|Nabu Casa ZBT-2|SMLight SLZB06-M|SMLight SLZB06mg24|SMLight SLZB06mg26|SMLight SLZB07|SMLight
+    SLZB07mg24|Sonoff ZBDongle-E|Sonoff Dongle-LMG21|Sonoff Dongle-M|Sonoff Dongle-PMG24|SparkFun MGM240p|TubeZB
+    MGM24|TubeZB BM24|ROUTER - Aeotec Zi-Stick (ZGA008)|ROUTER - EasyIOT ZB-GW04 v1.1|ROUTER - EasyIOT ZB-GW04
+    v1.2|ROUTER - Inswift ZBM-MG24|ROUTER - Nabu Casa SkyConnect|ROUTER - Nabu Casa Yellow|ROUTER - Nabu Casa
+    ZBT-2|ROUTER - SMLight SLZB06-M|ROUTER - SMLight SLZB06mg24|ROUTER - SMLight SLZB06mg26|ROUTER - SMLight
+    SLZB07|ROUTER - SMLight SLZB07mg24|ROUTER - Sonoff ZBDongle-E|ROUTER - Sonoff Dongle-LMG21|ROUTER - Sonoff
+    Dongle-M|ROUTER - Sonoff Dongle-PMG24|ROUTER - SparkFun MGM240p|ROUTER - TubeZB MGM24|ROUTER - TubeZB BM24] [--reset
+    ezsp|spinel|cpc|dtr-rts|baudrate] [--action info|update|clear-nvm3|clear-app|run] [--firmware <value>] [--nvm3-size
+    <value>] [--yes]
+
+FLAGS
+  --action=<option>
+      Execute a single bootloader action without the interactive menu, then exit the bootloader.
+      <options: info|update|clear-nvm3|clear-app|run>
+
+  --adapter=<option>
+      Adapter model (skips the interactive model prompt). Required for --action clear-nvm3/clear-app.
+      <options: Aeotec Zi-Stick (ZGA008)|EasyIOT ZB-GW04 v1.1|EasyIOT ZB-GW04 v1.2|Inswift ZBM-MG24|Nabu Casa
+      SkyConnect|Nabu Casa Yellow|Nabu Casa ZBT-2|SMLight SLZB06-M|SMLight SLZB06mg24|SMLight SLZB06mg26|SMLight
+      SLZB07|SMLight SLZB07mg24|Sonoff ZBDongle-E|Sonoff Dongle-LMG21|Sonoff Dongle-M|Sonoff Dongle-PMG24|SparkFun
+      MGM240p|TubeZB MGM24|TubeZB BM24|ROUTER - Aeotec Zi-Stick (ZGA008)|ROUTER - EasyIOT ZB-GW04 v1.1|ROUTER - EasyIOT
+      ZB-GW04 v1.2|ROUTER - Inswift ZBM-MG24|ROUTER - Nabu Casa SkyConnect|ROUTER - Nabu Casa Yellow|ROUTER - Nabu Casa
+      ZBT-2|ROUTER - SMLight SLZB06-M|ROUTER - SMLight SLZB06mg24|ROUTER - SMLight SLZB06mg26|ROUTER - SMLight
+      SLZB07|ROUTER - SMLight SLZB07mg24|ROUTER - Sonoff ZBDongle-E|ROUTER - Sonoff Dongle-LMG21|ROUTER - Sonoff
+      Dongle-M|ROUTER - Sonoff Dongle-PMG24|ROUTER - SparkFun MGM240p|ROUTER - TubeZB MGM24|ROUTER - TubeZB BM24>
+
+  --baudrate=<value>
+      [default: 115200] Baudrate the installed firmware runs at (with --port). One of: 115200, 230400, 460800, 921600.
+
+  --firmware=<value>
+      Firmware file path or URL (with --action update).
+
+  --flow=<option>
+      [default: software] Flow control (with --port).
+      <options: hardware|software>
+
+  --nvm3-size=<value>
+      NVM3 size in bytes (with --action clear-nvm3). One of: 32768, 40960.
+
+  --port=<value>
+      Serial port path (or tcp://host:port). Enables unattended mode for the connection (no prompts).
+
+  --reset=<option>
+      How to launch the bootloader when the adapter is running firmware (skips the interactive prompt).
+      <options: ezsp|spinel|cpc|dtr-rts|baudrate>
+
+  --yes
+      Skip confirmations (required for unattended --action runs).
 
 DESCRIPTION
   Interact with the Gecko bootloader in the adapter.
 
 EXAMPLES
   $ ember-zli bootloader
+
+  $ ember-zli bootloader --port /dev/serial/by-id/usb-... --baudrate 115200 --adapter "Sonoff Dongle-PMG24" --reset dtr-rts --action update --firmware ./fw.gbl --yes
+
+  $ ember-zli bootloader --port /dev/ttyUSB0 --adapter "Sonoff Dongle-PMG24" --reset dtr-rts --action clear-nvm3 --nvm3-size 32768 --yes
 ```
 
 _See code: [src/commands/bootloader/index.ts](https://github.com/Nerivec/ember-zli/blob/v4.2.3/src/commands/bootloader/index.ts)_

--- a/src/commands/bootloader/index.ts
+++ b/src/commands/bootloader/index.ts
@@ -1,36 +1,101 @@
 import { readFileSync } from "node:fs";
 import { confirm, input, select } from "@inquirer/prompts";
-import { Command } from "@oclif/core";
+import { Command, Flags } from "@oclif/core";
 import { Presets, SingleBar } from "cli-progress";
 import { DEFAULT_FIRMWARE_GBL_PATH, logger } from "../../index.js";
-import { BootloaderEvent, BootloaderMenu, GeckoBootloader } from "../../utils/bootloader.js";
-import { ADAPTER_MODELS, PRE_DEFINED_FIRMWARE_LINKS_URL } from "../../utils/consts.js";
+import { BOOTLOADER_RESET_METHODS, BootloaderEvent, BootloaderMenu, type BootloaderResetMethod, GeckoBootloader } from "../../utils/bootloader.js";
+import { ADAPTER_MODELS, BAUDRATES, PRE_DEFINED_FIRMWARE_LINKS_URL, TCP_REGEX } from "../../utils/consts.js";
 import { FirmwareValidation } from "../../utils/enums.js";
 import { getPortConf } from "../../utils/port.js";
-import type { AdapterModel, FirmwareLinks, FirmwareVariant, SelectChoices } from "../../utils/types.js";
+import type { AdapterModel, FirmwareLinks, FirmwareVariant, PortConf, SelectChoices } from "../../utils/types.js";
 import { browseToFile, fetchJson } from "../../utils/utils.js";
+
+const SCRIPTED_ACTIONS = ["info", "update", "clear-nvm3", "clear-app", "run"] as const;
+type ScriptedAction = (typeof SCRIPTED_ACTIONS)[number];
 
 export default class Bootloader extends Command {
     static override args = {};
     static override description = "Interact with the Gecko bootloader in the adapter.";
-    static override examples = ["<%= config.bin %> <%= command.id %>"];
+    static override examples = [
+        "<%= config.bin %> <%= command.id %>",
+        '<%= config.bin %> <%= command.id %> --port /dev/serial/by-id/usb-... --baudrate 115200 --adapter "Sonoff Dongle-PMG24" --reset dtr-rts --action update --firmware ./fw.gbl --yes',
+        '<%= config.bin %> <%= command.id %> --port /dev/ttyUSB0 --adapter "Sonoff Dongle-PMG24" --reset dtr-rts --action clear-nvm3 --nvm3-size 32768 --yes',
+    ];
+    static override flags = {
+        port: Flags.string({
+            description: "Serial port path (or tcp://host:port). Enables unattended mode for the connection (no prompts).",
+        }),
+        baudrate: Flags.integer({
+            default: 115200,
+            description: `Baudrate the installed firmware runs at (with --port). One of: ${BAUDRATES.join(", ")}.`,
+        }),
+        flow: Flags.string({
+            default: "software",
+            description: "Flow control (with --port).",
+            options: ["hardware", "software"],
+        }),
+        adapter: Flags.string({
+            description: "Adapter model (skips the interactive model prompt). Required for --action clear-nvm3/clear-app.",
+            options: [...ADAPTER_MODELS],
+        }),
+        reset: Flags.string({
+            description: "How to launch the bootloader when the adapter is running firmware (skips the interactive prompt).",
+            options: [...BOOTLOADER_RESET_METHODS],
+        }),
+        action: Flags.string({
+            description: "Execute a single bootloader action without the interactive menu, then exit the bootloader.",
+            options: [...SCRIPTED_ACTIONS],
+        }),
+        firmware: Flags.string({
+            description: "Firmware file path or URL (with --action update).",
+        }),
+        "nvm3-size": Flags.integer({
+            description: "NVM3 size in bytes (with --action clear-nvm3). One of: 32768, 40960.",
+        }),
+        yes: Flags.boolean({
+            default: false,
+            description: "Skip confirmations (required for unattended --action runs).",
+        }),
+    };
 
     public async run(): Promise<void> {
-        const portConf = await getPortConf();
-        logger.debug(`Using port conf: ${JSON.stringify(portConf)}`);
+        const { flags } = await this.parse(Bootloader);
 
-        const adapterModelChoices: SelectChoices<AdapterModel | undefined> = [{ name: "Not in this list", value: undefined }];
-
-        for (const model of ADAPTER_MODELS) {
-            adapterModelChoices.push({ name: model, value: model });
+        if (flags.action && !flags.yes) {
+            this.error("--action requires --yes: unattended actions cannot stop for confirmation prompts.");
         }
 
-        const adapterModel = await select<AdapterModel | undefined>({
-            choices: adapterModelChoices,
-            message: "Adapter model",
-        });
+        if (flags.action === "update" && !flags.firmware) {
+            this.error("--action update requires --firmware.");
+        }
 
-        const gecko = new GeckoBootloader(portConf, adapterModel);
+        if (flags.action === "clear-nvm3" && flags["nvm3-size"] !== 32768 && flags["nvm3-size"] !== 40960) {
+            this.error("--action clear-nvm3 requires --nvm3-size (32768 or 40960).");
+        }
+
+        if ((flags.action === "clear-nvm3" || flags.action === "clear-app") && !flags.adapter) {
+            this.error(`--action ${flags.action} requires --adapter (used to pick the matching recovery image).`);
+        }
+
+        const portConf = flags.port ? this.makePortConf(flags.port, flags.baudrate, flags.flow) : await getPortConf();
+        logger.debug(`Using port conf: ${JSON.stringify(portConf)}`);
+
+        let adapterModel = flags.adapter as AdapterModel | undefined;
+
+        if (adapterModel === undefined && !flags.action) {
+            const adapterModelChoices: SelectChoices<AdapterModel | undefined> = [{ name: "Not in this list", value: undefined }];
+
+            for (const model of ADAPTER_MODELS) {
+                adapterModelChoices.push({ name: model, value: model });
+            }
+
+            adapterModel = await select<AdapterModel | undefined>({
+                choices: adapterModelChoices,
+                message: "Adapter model",
+            });
+        }
+
+        const gecko = new GeckoBootloader(portConf, adapterModel, { skipConfirmations: flags.yes });
         const progressBar = new SingleBar({ clearOnComplete: true, format: "{bar} {percentage}%" }, Presets.shades_classic);
 
         gecko.on(BootloaderEvent.FAILED, () => {
@@ -53,17 +118,105 @@ export default class Bootloader extends Command {
             progressBar.update(percent);
         });
 
-        await gecko.connect();
+        await gecko.connect(flags.reset as BootloaderResetMethod | undefined);
 
-        let exit = false;
+        if (flags.action) {
+            await this.runScriptedAction(gecko, flags.action as ScriptedAction, flags.firmware, flags["nvm3-size"]);
+        } else {
+            let exit = false;
 
-        while (!exit) {
-            exit = await this.navigateMenu(gecko);
+            while (!exit) {
+                exit = await this.navigateMenu(gecko);
+            }
         }
 
         await gecko.transport.close(false);
 
         return this.exit(0);
+    }
+
+    private makePortConf(path: string, baudRate: number, flow: string): PortConf {
+        if (!TCP_REGEX.test(path) && !BAUDRATES.includes(baudRate)) {
+            this.error(`--baudrate must be one of: ${BAUDRATES.join(", ")}.`);
+        }
+
+        const rtscts = flow === "hardware";
+
+        return { baudRate, path, rtscts, xon: !rtscts, xoff: !rtscts };
+    }
+
+    private async runScriptedAction(
+        gecko: GeckoBootloader,
+        action: ScriptedAction,
+        firmwareSource: string | undefined,
+        nvm3Size: number | undefined,
+    ): Promise<void> {
+        switch (action) {
+            case "info": {
+                await gecko.navigate(BootloaderMenu.INFO);
+                break;
+            }
+
+            case "run": {
+                await gecko.navigate(BootloaderMenu.RUN);
+                break;
+            }
+
+            case "update": {
+                // checked in run(): --action update requires --firmware
+                const firmware = await this.loadFirmware(firmwareSource!);
+
+                if (firmware === undefined || (await gecko.validateFirmware(firmware)) !== FirmwareValidation.VALID) {
+                    this.error("Failed to load a valid firmware file.");
+                }
+
+                if (await gecko.navigate(BootloaderMenu.UPLOAD_GBL, firmware)) {
+                    this.error("Firmware upload failed.");
+                }
+
+                await gecko.navigate(BootloaderMenu.RUN);
+                break;
+            }
+
+            case "clear-nvm3":
+            case "clear-app": {
+                // checked in run(): these actions require --adapter
+                const firmwareLinks = await fetchJson<FirmwareLinks>(PRE_DEFINED_FIRMWARE_LINKS_URL);
+                const variant = action === "clear-app" ? "app_clear" : nvm3Size === 32768 ? "nvm3_32768_clear" : "nvm3_40960_clear";
+                const url = firmwareLinks[variant][gecko.adapterModel!];
+
+                if (!url) {
+                    this.error(`No '${variant}' recovery image is available for ${gecko.adapterModel}.`);
+                }
+
+                const firmware = await this.downloadFirmware(url);
+
+                if (firmware === undefined) {
+                    this.error("Failed to download the recovery image.");
+                }
+
+                if (await gecko.navigate(action === "clear-app" ? BootloaderMenu.CLEAR_APP : BootloaderMenu.CLEAR_NVM3, firmware)) {
+                    this.error(`${action} failed.`);
+                }
+
+                await gecko.navigate(BootloaderMenu.RUN);
+                break;
+            }
+        }
+    }
+
+    private async loadFirmware(source: string): Promise<Buffer | undefined> {
+        if (source.startsWith("http://") || source.startsWith("https://")) {
+            return await this.downloadFirmware(source);
+        }
+
+        try {
+            return readFileSync(source);
+        } catch (error) {
+            logger.error(`Failed to read firmware file ${source} with error ${error}.`);
+        }
+
+        return undefined;
     }
 
     private async navigateMenu(gecko: GeckoBootloader): Promise<boolean> {

--- a/src/utils/bootloader.ts
+++ b/src/utils/bootloader.ts
@@ -89,6 +89,15 @@ const enum FirmwareType {
     MULTIPROTOCOL_RCP = 2,
 }
 
+/** Reset methods selectable without prompting (for unattended runs). */
+export const BOOTLOADER_RESET_METHODS = ["ezsp", "spinel", "cpc", "dtr-rts", "baudrate"] as const;
+export type BootloaderResetMethod = (typeof BOOTLOADER_RESET_METHODS)[number];
+
+export type GeckoBootloaderOptions = {
+    /** Skip interactive confirmations (unattended runs). Default: false. */
+    skipConfirmations?: boolean;
+};
+
 interface GeckoBootloaderEventMap {
     [BootloaderEvent.CLOSED]: [];
     [BootloaderEvent.FAILED]: [];
@@ -113,13 +122,16 @@ export class GeckoBootloader extends EventEmitter<GeckoBootloaderEventMap> {
           }
         | undefined;
 
-    constructor(portConf: PortConf, adapterModel?: AdapterModel) {
+    private readonly skipConfirmations: boolean;
+
+    constructor(portConf: PortConf, adapterModel?: AdapterModel, options: GeckoBootloaderOptions = {}) {
         super();
 
         this.state = BootloaderState.NOT_CONNECTED;
         this.waiter = undefined;
         this.portConf = portConf;
         this.adapterModel = adapterModel;
+        this.skipConfirmations = options.skipConfirmations ?? false;
         // override config to default for serial gecko bootloader
         this.transport = new Transport({
             ...this.portConf,
@@ -138,7 +150,7 @@ export class GeckoBootloader extends EventEmitter<GeckoBootloaderEventMap> {
         this.xmodem.on(XEvent.DATA, this.onXModemData.bind(this));
     }
 
-    public async connect(): Promise<void> {
+    public async connect(resetMethod?: BootloaderResetMethod): Promise<void> {
         if (this.state !== BootloaderState.NOT_CONNECTED) {
             logger.debug("Already connected to bootloader. Skipping connect attempt.", NS);
             return;
@@ -152,17 +164,36 @@ export class GeckoBootloader extends EventEmitter<GeckoBootloaderEventMap> {
         // @ts-expect-error changed by received serial data
         if (this.state !== BootloaderState.IDLE) {
             const isTcp = TCP_REGEX.test(this.portConf.path);
-            // not already in bootloader, so launch it, then knock again
-            const resetType = await select<FirmwareType | 98 | 99>({
-                choices: [
-                    { name: "EmberZNet NCP (a.k.a. zigbee_ncp, ncp-uart-hw, EZSP NCP)", value: FirmwareType.EMBERZNET_NCP },
-                    { name: "OpenThread RCP (a.k.a. openthread_rcp, ot-rcp)", value: FirmwareType.OPENTHREAD_RCP },
-                    { name: "Multiprotocol RCP (a.k.a. rcp-uart-802154)", value: FirmwareType.MULTIPROTOCOL_RCP },
-                    { name: "Reset via DTR/RTS flipping", value: 98, disabled: isTcp },
-                    { name: "Reset via baudrate flipping", value: 99, disabled: isTcp },
-                ],
-                message: "Currently installed firmware or specific reset method",
-            });
+            let resetType: FirmwareType | 98 | 99;
+
+            if (resetMethod !== undefined) {
+                if (isTcp && (resetMethod === "dtr-rts" || resetMethod === "baudrate")) {
+                    logger.error(`Reset method '${resetMethod}' is not supported for TCP adapters.`, NS);
+                    this.emit(BootloaderEvent.FAILED);
+                    return;
+                }
+
+                const resetTypes: Record<BootloaderResetMethod, FirmwareType | 98 | 99> = {
+                    ezsp: FirmwareType.EMBERZNET_NCP,
+                    spinel: FirmwareType.OPENTHREAD_RCP,
+                    cpc: FirmwareType.MULTIPROTOCOL_RCP,
+                    "dtr-rts": 98,
+                    baudrate: 99,
+                };
+                resetType = resetTypes[resetMethod];
+            } else {
+                // not already in bootloader, so launch it, then knock again
+                resetType = await select<FirmwareType | 98 | 99>({
+                    choices: [
+                        { name: "EmberZNet NCP (a.k.a. zigbee_ncp, ncp-uart-hw, EZSP NCP)", value: FirmwareType.EMBERZNET_NCP },
+                        { name: "OpenThread RCP (a.k.a. openthread_rcp, ot-rcp)", value: FirmwareType.OPENTHREAD_RCP },
+                        { name: "Multiprotocol RCP (a.k.a. rcp-uart-802154)", value: FirmwareType.MULTIPROTOCOL_RCP },
+                        { name: "Reset via DTR/RTS flipping", value: 98, disabled: isTcp },
+                        { name: "Reset via baudrate flipping", value: 99, disabled: isTcp },
+                    ],
+                    message: "Currently installed firmware or specific reset method",
+                });
+            }
 
             switch (resetType) {
                 case FirmwareType.EMBERZNET_NCP: {
@@ -233,11 +264,9 @@ export class GeckoBootloader extends EventEmitter<GeckoBootloaderEventMap> {
                     return true;
                 }
 
-                const confirmed = await confirm({
-                    default: false,
-                    message:
-                        "Confirm APP clearing? (Cannot be undone; will erase the entire firmware (including NVM3). You MUST flash a new one afterwards.)",
-                });
+                const confirmed = await this.confirmOrSkip(
+                    "Confirm APP clearing? (Cannot be undone; will erase the entire firmware (including NVM3). You MUST flash a new one afterwards.)",
+                );
 
                 if (!confirmed) {
                     logger.warning("Cancelled APP clearing.", NS);
@@ -255,10 +284,7 @@ export class GeckoBootloader extends EventEmitter<GeckoBootloaderEventMap> {
                     return true;
                 }
 
-                const confirmed = await confirm({
-                    default: false,
-                    message: "Confirm NVM3 clearing? (Cannot be undone; will reset the adapter to factory defaults.)",
-                });
+                const confirmed = await this.confirmOrSkip("Confirm NVM3 clearing? (Cannot be undone; will reset the adapter to factory defaults.)");
 
                 if (!confirmed) {
                     logger.warning("Cancelled NVM3 clearing.", NS);
@@ -268,6 +294,16 @@ export class GeckoBootloader extends EventEmitter<GeckoBootloaderEventMap> {
                 return await this.menuUploadGBL(firmware);
             }
         }
+    }
+
+    /** Prompt for confirmation, or auto-accept (with a log line) in unattended runs. */
+    private async confirmOrSkip(message: string): Promise<boolean> {
+        if (this.skipConfirmations) {
+            logger.info(`Skipping confirmation: ${message}`, NS);
+            return true;
+        }
+
+        return await confirm({ default: false, message });
     }
 
     public async validateFirmware(firmware: Buffer | undefined): Promise<FirmwareValidation> {
@@ -298,10 +334,7 @@ export class GeckoBootloader extends EventEmitter<GeckoBootloaderEventMap> {
         const metaTagStart = firmware.lastIndexOf(GBL_METADATA_TAG);
 
         if (metaTagStart === -1) {
-            const proceed = await confirm({
-                default: false,
-                message: "Firmware file does not contain metadata. Cannot validate it. Proceed with this firmware?",
-            });
+            const proceed = await this.confirmOrSkip("Firmware file does not contain metadata. Cannot validate it. Proceed with this firmware?");
 
             if (!proceed) {
                 logger.warning("Cancelling firmware update.", NS);
@@ -349,10 +382,9 @@ export class GeckoBootloader extends EventEmitter<GeckoBootloaderEventMap> {
                 }
             }
 
-            const proceed = await confirm({
-                default: false,
-                message: `Version: ${recdMetadata.fw_version ?? recdMetadata.ezsp_version ?? recdMetadata.ot_version ?? recdMetadata.cpc_version}, Baudrate: ${recdMetadata.baudrate}. Proceed with this firmware?`,
-            });
+            const proceed = await this.confirmOrSkip(
+                `Version: ${recdMetadata.fw_version ?? recdMetadata.ezsp_version ?? recdMetadata.ot_version ?? recdMetadata.cpc_version}, Baudrate: ${recdMetadata.baudrate}. Proceed with this firmware?`,
+            );
 
             if (!proceed) {
                 logger.warning("Cancelling firmware update.", NS);


### PR DESCRIPTION
Implements #201: an unattended mode for `ember-zli bootloader`, so the whole flow can run scripted/headless (e.g. adapter recovery over SSH). The interactive experience is untouched when no flags are given.

### Usage

```bash
# flash a local firmware file
ember-zli bootloader \
  --port /dev/serial/by-id/usb-SONOFF_... --baudrate 115200 \
  --adapter "Sonoff Dongle-PMG24" --reset dtr-rts \
  --action update --firmware ./fw.gbl --yes

# factory-reset (NVM3 clear)
ember-zli bootloader --port /dev/ttyUSB0 --adapter "Sonoff Dongle-PMG24" \
  --reset dtr-rts --action clear-nvm3 --nvm3-size 32768 --yes
```

### Design

* Every prompt has a flag counterpart: `--port/--baudrate/--flow` (connection), `--adapter` (model select), `--reset` (the "currently installed firmware or reset method" select), `--action` + `--firmware`/`--nvm3-size` (menu), `--yes` (confirmations).
* `--action` runs exactly one menu action and then exits the bootloader (`RUN`), mirroring the common interactive sequence. `update` accepts a file path or URL; `clear-nvm3`/`clear-app` fetch the matching silabs-firmware-recovery image via the existing firmware-links mechanism (hence they require `--adapter`).
* Unattended runs must never hang on a prompt, so `--action` requires `--yes`; missing prerequisites (`--firmware`, `--nvm3-size`, `--adapter`) error out up front instead of falling back to prompts.
* `GeckoBootloader` changes are additive and non-breaking: an optional `options` constructor arg (`skipConfirmations`, which logs each skipped confirmation), and an optional `connect(resetMethod?)` param that bypasses the reset-method select (validated against TCP).

### Validation

* `tsc -b` clean, `biome check:ci` clean, README regenerated via `oclif readme`.
* Flag-validation paths smoke-tested (`--action` without `--yes`/`--firmware`/`--adapter`/`--nvm3-size` all error correctly before any port is touched).
* Hardware context: this mirrors exactly the interactive sequences we ran (successfully, repeatedly) on a Sonoff Dongle-PMG24 while recovering/migrating a coordinator over SSH — the motivation in #201. Happy to re-test any revision on that hardware.
